### PR TITLE
Refactor command line flag parsing to include required env vars

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14.6"
+          go-version: "1.17.0"
       - name: go test
         run: go test -coverprofile=coverage.txt ./...
       - name: upload codecov
@@ -58,7 +58,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14.6"
+          go-version: "1.17.0"
       - run: make crosscompile -j$(nproc)
       - name: Upload tink-cli binaries
         uses: actions/upload-artifact@v2

--- a/cmd/tink-worker/main.go
+++ b/cmd/tink-worker/main.go
@@ -8,12 +8,13 @@ import (
 )
 
 func main() {
-	cmdlineFlags, err := cmd.CollectCmdlineFlags(os.Args[1:])
+	// parse and validate command-line flags and required env vars
+	flagEnvSettings, err := cmd.CollectFlagEnvSettings(os.Args[1:])
 	if err != nil {
 		fmt.Println("Error:", err)
 		os.Exit(1)
 	}
 
-	// Remove me: this is just here to prevent linter issues
-	fmt.Printf("Version flag is %v\n", cmdlineFlags.Version)
+	// Remove me: this is just here during developent to prevent linter issues
+	fmt.Printf("Version flag is %v\n", flagEnvSettings.Version)
 }


### PR DESCRIPTION
This expands the scope of the command line flag related functions to
also handle environment variables which are required, but unrelated to
command line flags.

Signed-off-by: Scott Garman <sgarman@equinix.com>