### PR TITLE
Establish a connection to tink-server (GRPC)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17.0"
+          go-version: "1.17.4"
       - name: make verify
         run: make verify
   test:
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14.6"
+          go-version: "1.17.4"
       - name: go test
         run: go test -coverprofile=coverage.txt ./...
       - name: upload codecov
@@ -58,7 +58,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14.6"
+          go-version: "1.17.4"
       - run: make crosscompile -j$(nproc)
       - name: Upload tink-cli binaries
         uses: actions/upload-artifact@v2

--- a/cmd/tink-worker/client/tink/tink.go
+++ b/cmd/tink-worker/client/tink/tink.go
@@ -1,0 +1,59 @@
+package tink
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// ObtainServerCreds obtains tink-server credentials from the TLS certificate found at certURL.
+func ObtainServerCreds(certURL string) (credentials.TransportCredentials, error) {
+	// fetch the cert
+	if certURL == "" {
+		return nil, errors.New("certURL cannot be empty")
+	}
+	resp, err := http.Get(certURL)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to fetch cert from %s", certURL)
+		return nil, errors.New(errMsg)
+	}
+	defer resp.Body.Close()
+
+	// read the cert
+	certs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.New("unable to read the cert data")
+	}
+
+	// parse the cert
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(certs)
+	if !ok {
+		return nil, errors.New("unable to parse the cert data")
+	}
+
+	// generate credentials from the certPool
+	creds := credentials.NewClientTLSFromCert(certPool, "")
+
+	return creds, err
+}
+
+// EstablishServerConnection returns a GRPC client connection to tink-server.
+func EstablishServerConnection(grpcAuthority string, creds credentials.TransportCredentials) (*grpc.ClientConn, error) {
+	// use the cert creds to connect to the server
+	if grpcAuthority == "" {
+		return nil, errors.New("grpcAuthority cannot be empty")
+	}
+
+	conn, err := grpc.Dial(grpcAuthority, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, errors.New("connect to tinkerbell server")
+	}
+
+	return conn, nil
+}

--- a/cmd/tink-worker/client/tink/tink_test.go
+++ b/cmd/tink-worker/client/tink/tink_test.go
@@ -1,0 +1,151 @@
+package tink
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/packethost/pkg/grpc"
+	"github.com/packethost/pkg/log"
+	"github.com/tinkerbell/tink/protos/workflow"
+	ggrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// Self-signed cert we use to test credential generation.
+const selfSignedCert string = `-----BEGIN CERTIFICATE-----
+MIIB0DCCATGgAwIBAgIBATAKBggqhkjOPQQDBDASMRAwDgYDVQQKEwdBY21lIENv
+MB4XDTIxMTIwODIzNTYwMFoXDTIyMDYwNjIzNTYwMFowEjEQMA4GA1UEChMHQWNt
+ZSBDbzCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEAL71xJa5btFlW1BUaxrLAbsM
+1tgi0UTB6w4CHm+6iwyuP0BZD9eMwSjMzhZ70lmlah0Z5Z8oHFHEFOIYZnIG4O/r
+ATnzswVeVIPuX8uZ6ApsKq5q9uk9ByJIRfLhNqmrpLNSGbdcNEIoI27DIwiQdeT8
+U6WYuWZB8BKBNre2Q/OiAcPNozUwMzAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAww
+CgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADAKBggqhkjOPQQDBAOBjAAwgYgCQgE1
+AkrK0PoP1Mvia0jMGYBDwGzBCLjqPpPFuTE0pVJctog/ZXBRUDlSz9BN3PbCFJZs
+F+/RUdtxQsgcBeBNrKk2qwJCAVxHlTzNK+hv7Xr3MXC39TopWJuNEj/1B37FZ8HG
+0qv7ie1O3lcrMXd9evsIp9KLqSgUCyxmN2SS6LKBjaAwzmJd
+-----END CERTIFICATE-----`
+
+type fakeServer struct {
+	workflow.WorkflowServiceServer
+	data map[string]string
+	err  error
+}
+
+const bufSize = 1024 * 1024
+
+func startWorkflowServerAndConnectClient(t *testing.T, name string, server *grpc.Server) workflow.WorkflowServiceClient {
+	t.Helper()
+
+	ctx := context.Background()
+	listener := bufconn.Listen(bufSize)
+	go func() {
+		t.Helper()
+
+		if err := server.Server().Serve(listener); err != nil {
+			t.Error(fmt.Errorf("%s.Serve exited with error: %w", name, err))
+		}
+	}()
+
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return listener.DialContext(ctx)
+	}
+
+	conn, err := ggrpc.DialContext(ctx, "bufnet", ggrpc.WithContextDialer(dialer), ggrpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Failed to dial %s: %v", name, err)
+	}
+
+	client := workflow.NewWorkflowServiceClient(conn)
+	return client
+}
+
+func TestObtainServerCredsWithInvalidCerts(t *testing.T) {
+	emptyCert := ""
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, emptyCert)
+	}))
+	defer svr.Close()
+
+	certTests := []struct {
+		testName         string
+		url              string
+		expectedErrorMsg string
+	}{
+		{"certURL arg validation", "", "certURL cannot be empty"},
+		{"ensure we get a response when fetching a cert", "something", "unable to fetch cert from something"},
+		{"ensure an empty cert response is rejected", svr.URL, "unable to parse the cert data"},
+	}
+	for _, tt := range certTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			_, err := ObtainServerCreds(tt.url)
+			if err == nil {
+				t.Fatal("Error expected but none found")
+			} else if fmt.Sprint(err) != tt.expectedErrorMsg {
+				t.Fatalf("Error should be %v, got %v", tt.expectedErrorMsg, err)
+			}
+		})
+	}
+}
+
+func TestObtainServerCredsWithValidCert(t *testing.T) {
+	t.Run("using with a self-signed cert", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, selfSignedCert)
+		}))
+		defer server.Close()
+
+		_, err := ObtainServerCreds(server.URL)
+		if err != nil {
+			t.Fatalf("Error obtaining tink server creds: %v", err)
+		}
+	})
+}
+
+func TestEstablishServerConnection(t *testing.T) {
+	t.Run("grpcAuthority arg validation", func(t *testing.T) {
+		expectedErrorMsg := "grpcAuthority cannot be empty"
+		_, err := EstablishServerConnection("", nil)
+		if err == nil {
+			t.Fatal("Error expected but none found")
+		} else if fmt.Sprint(err) != expectedErrorMsg {
+			t.Fatalf("Error should be %v, got %v", expectedErrorMsg, err)
+		}
+	})
+
+	t.Run("attempt to connect to a bogus GRPC server", func(t *testing.T) {
+		expectedErrorMsg := "connect to tinkerbell server"
+		_, err := EstablishServerConnection("bogus", nil)
+		if err == nil {
+			t.Fatal("Error expected but none found")
+		} else if fmt.Sprint(err) != expectedErrorMsg {
+			t.Fatalf("Error should be %v, got %v", expectedErrorMsg, err)
+		}
+	})
+}
+
+func TestClientCreation(t *testing.T) {
+	t.Run("ability to create a WorkflowServiceClient", func(t *testing.T) {
+		name := "tinkWorkflowServer"
+		fakeServer, err := grpc.NewServer(log.Test(t, name), func(s *grpc.Server) {
+			workflow.RegisterWorkflowServiceServer(s.Server(), &fakeServer{
+				data: nil,
+				err:  nil,
+			})
+		})
+		if err != nil {
+			t.Fatalf("Error: %s", err)
+		}
+		if fakeServer == nil {
+			t.Fatal("Error creating workflow server (server is nil)")
+		}
+
+		fakeClient := startWorkflowServerAndConnectClient(t, name, fakeServer)
+		if fakeClient == nil {
+			t.Fatal("Error creating workflow client (client is nil)")
+		}
+	})
+}

--- a/cmd/tink-worker/main.go
+++ b/cmd/tink-worker/main.go
@@ -8,12 +8,13 @@ import (
 )
 
 func main() {
-	cmdlineFlags, err := cmd.CollectCmdlineFlags(os.Args[1:])
+	// parse and validate command-line flags and required env vars
+	flagEnvSettings, err := cmd.CollectFlagEnvSettings(os.Args[1:])
 	if err != nil {
 		fmt.Println("Error:", err)
 		os.Exit(1)
 	}
 
-	// Remove me: this is just here to prevent linter issues
-	fmt.Printf("Version flag is %v\n", cmdlineFlags.Version)
+	// Remove me: this is just here during developent to prevent linter issues
+	fmt.Printf("Version flag is %v\n", flagEnvSettings.Version)
 }

--- a/cmd/tink-worker/main.go
+++ b/cmd/tink-worker/main.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
+	"github.com/tinkerbell/tink/cmd/tink-worker/client/tink"
 	"github.com/tinkerbell/tink/cmd/tink-worker/cmd"
+	"github.com/tinkerbell/tink/protos/workflow"
+	"google.golang.org/grpc"
 )
 
 func main() {
@@ -12,6 +17,37 @@ func main() {
 	flagEnvSettings, err := cmd.CollectFlagEnvSettings(os.Args[1:])
 	if err != nil {
 		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+
+	// Here we retry failed connections to tink-server using a randomized interval between attempts.
+	// tink-worker is a daemon process, so we do not exit here.
+	var conn *grpc.ClientConn
+	for {
+		creds, err := tink.ObtainServerCreds(flagEnvSettings.TinkServerURL)
+		if err == nil {
+			conn, err = tink.EstablishServerConnection(flagEnvSettings.TinkServerGRPCAuthority, creds)
+			if err == nil {
+				break
+			}
+			fmt.Printf("Error establishing gPRC connection to tink-server at %s: %v:", flagEnvSettings.TinkServerGRPCAuthority, err)
+		} else {
+			fmt.Printf("Error obtaining server creds from %s: %v", flagEnvSettings.TinkServerURL, err)
+		}
+
+		// sleep a randomized amount of time before reconnecting to avoid thundering herds
+		// TODO: we may want to make this configurable via a cmdline option?
+		rand.Seed(time.Now().UnixNano())
+		s := rand.Intn(120) + 1 // 2 minutes (120 seconds), plus one second to avoid a possible zero sleep time
+		fmt.Printf("Sleeping %d seconds before attempting to re-connect...\n", s)
+		time.Sleep(time.Duration(s) * time.Second)
+	}
+
+	workflowClient := workflow.NewWorkflowServiceClient(conn)
+
+	// TODO: this is just here during developent to prevent linter issues, remove this
+	if workflowClient == nil {
+		fmt.Println("We already check conn so there's no way these could actually be nil")
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.22.0
 	google.golang.org/genproto v0.0.0-20210921142501-181ce0d877f6
-	google.golang.org/grpc v1.41.0-dev.0.20210907181116-2f3355d2244e
+	google.golang.org/grpc v1.41.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1895,6 +1895,8 @@ google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.41.0-dev.0.20210907181116-2f3355d2244e h1:HKKXKZmOaf1UtYn+/ga7+QSLvK7l6K5Mppj9yGgXYCo=
 google.golang.org/grpc v1.41.0-dev.0.20210907181116-2f3355d2244e/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
+google.golang.org/grpc v1.41.0 h1:f+PlOh7QV4iIJkPrx5NQ7qaNGFQ3OTse67yaDHfju4E=
+google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=


### PR DESCRIPTION
This builds further on PR #2, and includes setting up the connection to tink-server and establishing our clients.

Worth noting:
* Right now, all of the workflow client methods are stubbed out in the client test code. We can fill these in as needed as we add more code. Many of the interface methods are not used by tink-worker anyway.
* I stopped writing test helpers for assertions based on feedback about the idiomatic way of writing Go test code.