### PR TITLE
Refactor tink worker: abstraction around all Tink server calls

### DIFF
--- a/cmd/tink-worker/tink/tink.go
+++ b/cmd/tink-worker/tink/tink.go
@@ -1,0 +1,61 @@
+package tink
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	pb "github.com/tinkerbell/tink/protos/workflow"
+)
+
+type WorkflowData struct{}
+
+// WorkflowContexts gets workflow context for worker id on success else returns error.
+func (w WorkflowData) WorkflowContexts(ctx context.Context, client pb.WorkflowServiceClient, workerID string) (pb.WorkflowService_GetWorkflowContextsClient, error) {
+	if workerID == "" {
+		return nil, errors.New("empty string is not a valid worker id")
+	}
+
+	if client == nil {
+		return nil, errors.New("nil WorkflowServiceClient is not a valid interface")
+	}
+
+	response, err := client.GetWorkflowContexts(ctx, &pb.WorkflowContextRequest{WorkerId: workerID})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get workflow contexts")
+	}
+	return response, nil
+}
+
+// WorkflowActions gets workflow action list for workflow id on success else returns error.
+func (w WorkflowData) WorkflowActions(ctx context.Context, client pb.WorkflowServiceClient, workflowID string) (*pb.WorkflowActionList, error) {
+	if workflowID == "" {
+		return nil, errors.New("empty string is not a valid workflow id")
+	}
+
+	if client == nil {
+		return nil, errors.New("nil WorkflowServiceClient is not a valid interface")
+	}
+
+	actions, err := client.GetWorkflowActions(ctx, &pb.WorkflowActionsRequest{WorkflowId: workflowID})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get workflow actions")
+	}
+	return actions, nil
+}
+
+// ReportWorkflowActionStatus reports action status on success else returns error.
+func (w WorkflowData) ReportWorkflowActionStatus(ctx context.Context, client pb.WorkflowServiceClient, actionStatus *pb.WorkflowActionStatus) error {
+	if client == nil {
+		return errors.New("nil WorkflowServiceClient is not a valid interface")
+	}
+
+	if actionStatus == nil {
+		return errors.New("nil WorkflowActionStatus is not a valid action status")
+	}
+
+	_, err := client.ReportActionStatus(ctx, actionStatus)
+	if err != nil {
+		return errors.Wrap(err, "failed to report action status")
+	}
+	return err
+}

--- a/cmd/tink-worker/tink/tink_test.go
+++ b/cmd/tink-worker/tink/tink_test.go
@@ -1,0 +1,257 @@
+package tink
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	pb "github.com/tinkerbell/tink/protos/workflow"
+	"google.golang.org/grpc"
+)
+
+type mockCli struct {
+	pb.WorkflowServiceClient
+	response     pb.WorkflowService_GetWorkflowContextsClient
+	actionstatus pb.WorkflowActionStatus
+	actionlist   *pb.WorkflowActionList
+}
+
+func (mcli *mockCli) GetWorkflowContexts(ctx context.Context, _ *pb.WorkflowContextRequest, _ ...grpc.CallOption) (pb.WorkflowService_GetWorkflowContextsClient, error) {
+	if ctx == nil {
+		return nil, errors.New("nil context is not a valid interface")
+	}
+
+	return mcli.response, nil
+}
+
+func (mcli *mockCli) GetWorkflowActions(ctx context.Context, _ *pb.WorkflowActionsRequest, _ ...grpc.CallOption) (*pb.WorkflowActionList, error) {
+	if ctx == nil {
+		return nil, errors.New("nil context is not a valid interface")
+	}
+	return mcli.actionlist, nil
+}
+
+func (mcli *mockCli) ReportActionStatus(ctx context.Context, _ *pb.WorkflowActionStatus, _ ...grpc.CallOption) (*pb.Empty, error) {
+	if ctx == nil {
+		return nil, errors.New("nil context is not a valid interface")
+	}
+	return nil, nil
+}
+
+func TestWorkerGetWorkflowActions(t *testing.T) {
+	mock := &mockCli{}
+	type args struct {
+		ctx        context.Context
+		cli        pb.WorkflowServiceClient
+		workflowID string
+	}
+	tests := []struct {
+		name    string
+		data    args
+		w       WorkflowData
+		wantErr error
+	}{
+		{
+			name: "get_workflow_actions_with_workflowID",
+			data: args{
+				ctx:        context.Background(),
+				cli:        mock,
+				workflowID: "3431423",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "get_workflow_actions_with_no_workflowID",
+			data: args{
+				ctx:        context.Background(),
+				cli:        mock,
+				workflowID: "",
+			},
+			wantErr: errors.New("empty string is not a valid workflow id"),
+		},
+		{
+			name: "get_workflow_actions_with_no_service_client",
+			data: args{
+				ctx:        context.Background(),
+				cli:        nil,
+				workflowID: "3431423",
+			},
+			wantErr: errors.New("nil WorkflowServiceClient is not a valid interface"),
+		},
+		{
+			name: "get_workflow_actions_with_service_client",
+			data: args{
+				ctx:        context.Background(),
+				cli:        mock,
+				workflowID: "3431423",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "get_workflow_actions_with_no_context",
+			data: args{
+				ctx:        nil,
+				cli:        mock,
+				workflowID: "3431423",
+			},
+			wantErr: errors.New("failed to get workflow actions: nil context is not a valid interface"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.w.WorkflowActions(tt.data.ctx, tt.data.cli, tt.data.workflowID)
+			if err != nil {
+				diff := cmp.Diff(tt.wantErr.Error(), err.Error())
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestWorkerReportActionStatus(t *testing.T) {
+	mock := &mockCli{}
+	type args struct {
+		ctx          context.Context
+		cli          pb.WorkflowServiceClient
+		actionStatus *pb.WorkflowActionStatus
+	}
+	tests := []struct {
+		name    string
+		data    args
+		w       WorkflowData
+		wantErr error
+	}{
+		{
+			name: "get_worker_report_action_status_with_no_service_client",
+			data: args{
+				ctx:          context.Background(),
+				cli:          nil,
+				actionStatus: &mock.actionstatus,
+			},
+			wantErr: errors.New("nil WorkflowServiceClient is not a valid interface"),
+		},
+		{
+			name: "get_worker_report_action_status_with_service_client",
+			data: args{
+				ctx:          context.Background(),
+				cli:          mock,
+				actionStatus: &mock.actionstatus,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "get_worker_report_action_status_with_no_action_status",
+			data: args{
+				ctx:          context.Background(),
+				cli:          mock,
+				actionStatus: nil,
+			},
+			wantErr: errors.New("nil WorkflowActionStatus is not a valid action status"),
+		},
+		{
+			name: "get_worker_report_action_status_with_action_status",
+			data: args{
+				ctx:          context.Background(),
+				cli:          mock,
+				actionStatus: &mock.actionstatus,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "get_worker_report_action_status_with_no_context",
+			data: args{
+				ctx:          nil,
+				cli:          mock,
+				actionStatus: &mock.actionstatus,
+			},
+			wantErr: errors.New("failed to report action status: nil context is not a valid interface"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.w.ReportWorkflowActionStatus(tt.data.ctx, tt.data.cli, tt.data.actionStatus)
+			if err != nil {
+				diff := cmp.Diff(tt.wantErr.Error(), err.Error())
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestWorkerGetWorkflowContexts(t *testing.T) {
+	mock := &mockCli{}
+	type args struct {
+		ctx      context.Context
+		cli      pb.WorkflowServiceClient
+		workerID string
+	}
+	tests := []struct {
+		name    string
+		data    args
+		w       WorkflowData
+		wantErr error
+	}{
+		{
+			name: "get_worker_flow_context_with_no_service_client",
+			data: args{
+				ctx:      context.Background(),
+				cli:      nil,
+				workerID: "3431423",
+			},
+			wantErr: errors.New("nil WorkflowServiceClient is not a valid interface"),
+		},
+		{
+			name: "get_worker_flow_context_with_service_client",
+			data: args{
+				ctx:      context.Background(),
+				cli:      mock,
+				workerID: "3431423",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "get_worker_flow_context_with_workerID",
+			data: args{
+				ctx:      context.Background(),
+				cli:      mock,
+				workerID: "3431423",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "get_worker_flow_context_with_no_workerID",
+			data: args{
+				ctx:      context.Background(),
+				cli:      mock,
+				workerID: "",
+			},
+			wantErr: errors.New("empty string is not a valid worker id"),
+		},
+		{
+			name: "get_worker_flow_context_with_no_context",
+			data: args{
+				ctx:      nil,
+				cli:      mock,
+				workerID: "3431423",
+			},
+			wantErr: errors.New("failed to get workflow contexts: nil context is not a valid interface"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.w.WorkflowContexts(tt.data.ctx, tt.data.cli, tt.data.workerID)
+			if err != nil {
+				diff := cmp.Diff(tt.wantErr.Error(), err.Error())
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Wrapper for tinker server calls that are made for tink worker to
process workflow and actions.