### PR TITLE
Fix issues with gRPC connection retries

### DIFF
--- a/cmd/tink-worker/client/tink/tink_test.go
+++ b/cmd/tink-worker/client/tink/tink_test.go
@@ -54,6 +54,7 @@ func startWorkflowServerAndConnectClient(t *testing.T, name string, server *grpc
 		return listener.DialContext(ctx)
 	}
 
+	// nolint:staticcheck // suppress grpc.WithInsecure() deprecation warning
 	conn, err := ggrpc.DialContext(ctx, "bufnet", ggrpc.WithContextDialer(dialer), ggrpc.WithInsecure())
 	if err != nil {
 		t.Fatalf("Failed to dial %s: %v", name, err)

--- a/cmd/tink-worker/main.go
+++ b/cmd/tink-worker/main.go
@@ -16,41 +16,43 @@ func main() {
 	// parse and validate command-line flags and required env vars
 	flagEnvSettings, err := cmd.CollectFlagEnvSettings(os.Args[1:])
 	if err != nil {
-		fmt.Println("Error:", err)
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
+	}
+
+	// Randomized sleep function. Used when retrying failed connections to tink server.
+	sleepFn := func() {
+		rand.Seed(time.Now().UnixNano())
+		s := rand.Intn(120) + 1 // 2 minutes (120 seconds), plus one second to avoid a possible zero sleep time
+		fmt.Fprintf(os.Stderr, "Sleeping %d seconds before attempting to re-connect...\n", s)
+		time.Sleep(time.Duration(s) * time.Second)
 	}
 
 	// Here we retry failed connections to tink-server using a randomized interval between attempts.
 	// tink-worker is a daemon process, so we do not exit here.
 	var conn *grpc.ClientConn
 	for {
+		fmt.Fprintf(os.Stderr, "Obtaining tink server creds from %s...\n", flagEnvSettings.TinkServerURL)
 		creds, err := tink.ObtainServerCreds(flagEnvSettings.TinkServerURL)
-		if err == nil {
-			conn, err = tink.EstablishServerConnection(flagEnvSettings.TinkServerGRPCAuthority, creds)
-			if err == nil {
-				break
-			}
-			fmt.Printf("Error establishing gPRC connection to tink-server at %s: %v:", flagEnvSettings.TinkServerGRPCAuthority, err)
-		} else {
-			fmt.Printf("Error obtaining server creds from %s: %v", flagEnvSettings.TinkServerURL, err)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error obtaining server creds from %s: %v\n", flagEnvSettings.TinkServerURL, err)
+			sleepFn()
+			continue
 		}
 
-		// sleep a randomized amount of time before reconnecting to avoid thundering herds
-		// TODO: we may want to make this configurable via a cmdline option?
-		rand.Seed(time.Now().UnixNano())
-		s := rand.Intn(120) + 1 // 2 minutes (120 seconds), plus one second to avoid a possible zero sleep time
-		fmt.Printf("Sleeping %d seconds before attempting to re-connect...\n", s)
-		time.Sleep(time.Duration(s) * time.Second)
+		fmt.Fprintf(os.Stderr, "Connecting to tink-server...\n")
+		conn, err = tink.EstablishServerConnection(flagEnvSettings.TinkServerGRPCAuthority, creds)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error establishing gPRC connection to tink-server at %s: %v\n", flagEnvSettings.TinkServerGRPCAuthority, err)
+			sleepFn()
+			continue
+		}
+
+		break
 	}
 
-	workflowClient := workflow.NewWorkflowServiceClient(conn)
-
-	// TODO: this is just here during developent to prevent linter issues, remove this
-	if workflowClient == nil {
-		fmt.Println("We already check conn so there's no way these could actually be nil")
-		os.Exit(1)
+	wc := workflow.NewWorkflowServiceClient(conn)
+	if wc == nil {
+		fmt.Fprintf(os.Stderr, "Error creating a workflow client")
 	}
-
-	// Remove me: this is just here during developent to prevent linter issues
-	fmt.Printf("Version flag is %v\n", flagEnvSettings.Version)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/bufbuild/buf v1.0.0-rc2
 	github.com/docker/distribution v2.7.1+incompatible
-	github.com/docker/docker v20.10.7+incompatible // indirect
+	github.com/docker/docker v20.10.7+incompatible
 	github.com/equinix-labs/otel-init-go v0.0.1
 	github.com/go-openapi/strfmt v0.19.3 // indirect
 	github.com/golang/protobuf v1.5.2
@@ -19,7 +19,7 @@ require (
 	github.com/lib/pq v1.10.1
 	github.com/matryer/moq v0.2.3
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
-	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/opencontainers/image-spec v1.0.1
 	github.com/packethost/pkg v0.0.0-20200903155310-0433e0605550
 	github.com/peterbourgon/ff v1.7.1
 	github.com/pkg/errors v0.9.1
@@ -33,8 +33,9 @@ require (
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.22.0
 	google.golang.org/genproto v0.0.0-20210921142501-181ce0d877f6
-	google.golang.org/grpc v1.41.0
+	google.golang.org/grpc v1.43.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
+	google.golang.org/grpc/examples v0.0.0-20211222235408-78df8ec077fd // indirect
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
 	mvdan.cc/gofumpt v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,11 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
@@ -1838,6 +1841,7 @@ google.golang.org/genproto v0.0.0-20200626011028-ee7919e894b5/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200707001353-8e8330bf89df/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -1893,12 +1897,13 @@ google.golang.org/grpc v1.37.1/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQ
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.41.0-dev.0.20210907181116-2f3355d2244e h1:HKKXKZmOaf1UtYn+/ga7+QSLvK7l6K5Mppj9yGgXYCo=
 google.golang.org/grpc v1.41.0-dev.0.20210907181116-2f3355d2244e/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
-google.golang.org/grpc v1.41.0 h1:f+PlOh7QV4iIJkPrx5NQ7qaNGFQ3OTse67yaDHfju4E=
-google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
+google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
+google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/examples v0.0.0-20211222235408-78df8ec077fd h1:8EKJZwIkVFxWoIC1zreyLSZh/E2B7ANlqZ7UvJpjBJo=
+google.golang.org/grpc/examples v0.0.0-20211222235408-78df8ec077fd/go.mod h1:gID3PKrg7pWKntu9Ss6zTLJ0ttC0X9IHgREOCZwbCVU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/http-server/http_handlers_test.go
+++ b/http-server/http_handlers_test.go
@@ -66,6 +66,7 @@ func TestHardwarePushHandler(t *testing.T) {
 		t.Log(name)
 
 		mux := grpcRuntime.NewServeMux()
+		// nolint:staticcheck // suppress grpc.WithInsecure() deprecation warning
 		dialOpts := []grpc.DialOption{grpc.WithContextDialer(bufDialer), grpc.WithInsecure()}
 		grpcEndpoint := "localhost:42113"
 


### PR DESCRIPTION
The previous approach assumed that a network connection happened at the
time grpc.Dial() was called. This is not the case, that method only
returns a client conneciton object, and network activity doesn't happen
until the first rpc call is made.

This renames the EstablishServerConnection function to reflect this,
enables gRPC keepalive parameters, and ensures retries happen when the
first rpc call is made.

Signed-off-by: Scott Garman <sgarman@equinix.com>